### PR TITLE
회원 가입 및 로그인 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,11 +25,15 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
   implementation("org.springframework.boot:spring-boot-starter-data-redis")
   implementation("org.springframework.boot:spring-boot-starter-web")
+  implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
   implementation("org.jetbrains.kotlin:kotlin-reflect")
   developmentOnly("org.springframework.boot:spring-boot-devtools")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring30x:4.5.2")
+  implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+  runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+  implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/chung/me/livechatapi/config/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/chung/me/livechatapi/config/JwtAuthenticationFilter.kt
@@ -1,0 +1,53 @@
+package chung.me.livechatapi.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+private const val BEARER_PREFIX = "Bearer "
+
+@Component
+class JwtAuthenticationFilter(
+  private val jwtService: JwtService,
+  private val userDetailsService: UserDetailsService,
+) : OncePerRequestFilter() {
+
+  override fun doFilterInternal(
+    request: HttpServletRequest,
+    response: HttpServletResponse,
+    filterChain: FilterChain,
+  ) {
+    val authHeader = request.getHeader(HttpHeaders.AUTHORIZATION)
+
+    if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+      filterChain.doFilter(request, response)
+      return
+    }
+
+    val jwt = authHeader.substringAfter(BEARER_PREFIX)
+    val loginId = jwtService.extractLoginId(jwt)
+    request.setAttribute("loginId", loginId)
+
+    if (SecurityContextHolder.getContext().authentication == null) {
+      val userDetails = userDetailsService.loadUserByUsername(loginId)
+      if (jwtService.isTokenValid(jwt, userDetails)) {
+        SecurityContextHolder.getContext().authentication = UsernamePasswordAuthenticationToken(
+          userDetails,
+          null,
+          userDetails.authorities
+        ).apply {
+          this.details = WebAuthenticationDetailsSource().buildDetails(request)
+        }
+      }
+    }
+
+    filterChain.doFilter(request, response)
+  }
+}

--- a/src/main/kotlin/chung/me/livechatapi/config/JwtService.kt
+++ b/src/main/kotlin/chung/me/livechatapi/config/JwtService.kt
@@ -1,0 +1,78 @@
+package chung.me.livechatapi.config
+
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.io.Decoders
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.stereotype.Service
+import java.security.Key
+import java.util.*
+import java.util.function.Function
+
+@Service
+class JwtService(
+  @Value("\${spring.server.secretKey}") private val secretKey: String,
+) {
+
+  fun extractLoginId(token: String): String {
+    return extractClaim(token, Claims::getSubject)
+  }
+
+  private fun <T> extractClaim(token: String, claimsResolver: Function<Claims, T>): T {
+    val claims = extractAllClaims(token)
+    return claimsResolver.apply(claims)
+  }
+
+  fun generateAccessToken(userDetails: UserDetails): String {
+    return generateToken(emptyMap(), userDetails, 60 * 60 * 2)
+  }
+
+  fun generateRefreshToken(userDetails: UserDetails): String {
+    return generateToken(emptyMap(), userDetails, 60 * 60 * 24 * 7)
+  }
+
+  private fun generateToken(
+    extraClaims: Map<String, Any>,
+    userDetails: UserDetails,
+    expirationSeconds: Long,
+  ): String {
+    return Jwts
+      .builder()
+      .setClaims(extraClaims)
+      .setSubject(userDetails.username)
+      .setIssuedAt(Date(System.currentTimeMillis()))
+      .setExpiration(Date(System.currentTimeMillis() + 1000 * expirationSeconds))
+      .signWith(getSignInKey(), SignatureAlgorithm.HS256)
+      .compact()
+  }
+
+  fun isTokenValid(token: String, userDetails: UserDetails): Boolean {
+    val loginId = extractLoginId(token)
+    return loginId == userDetails.username && !isTokenExpired(token)
+  }
+
+  private fun isTokenExpired(token: String): Boolean {
+    return extractExpiration(token).before(Date())
+  }
+
+  private fun extractExpiration(token: String): Date {
+    return extractClaim(token, Claims::getExpiration)
+  }
+
+  private fun extractAllClaims(token: String): Claims {
+    return Jwts
+      .parserBuilder()
+      .setSigningKey(getSignInKey())
+      .build()
+      .parseClaimsJws(token)
+      .body
+  }
+
+  private fun getSignInKey(): Key {
+    val keyBytes = Decoders.BASE64.decode(secretKey)
+    return Keys.hmacShaKeyFor(keyBytes)
+  }
+}

--- a/src/main/kotlin/chung/me/livechatapi/config/SecurityConfig.kt
+++ b/src/main/kotlin/chung/me/livechatapi/config/SecurityConfig.kt
@@ -1,0 +1,77 @@
+package chung.me.livechatapi.config
+
+import chung.me.livechatapi.entity.Role
+import chung.me.livechatapi.repos.UserRepos
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.AuthenticationProvider
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig(
+  private val jwtAuthFilter: JwtAuthenticationFilter,
+  private val userRepos: UserRepos,
+  private val userDetailsService: UserDetailsService,
+) {
+
+  @Bean
+  fun filterChain(httpSecurity: HttpSecurity): SecurityFilterChain {
+    httpSecurity.csrf()
+      .disable()
+      .authorizeHttpRequests { auth ->
+        auth
+          .requestMatchers(
+            "/users/signup", "/users/signin"
+          ).permitAll()
+          .requestMatchers(
+            "/chats/**,/chartrooms/**"
+          ).hasAuthority(Role.MEMBER.name)
+          .anyRequest()
+          .authenticated()
+          .and()
+          .sessionManagement()
+          .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+          .and()
+          .authenticationProvider(authenticationProvider())
+          .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
+      }
+      .exceptionHandling {
+        it.authenticationEntryPoint { _, res, _ ->
+          res.status = HttpStatus.UNAUTHORIZED.value()
+          res.contentType = MediaType.APPLICATION_JSON.type
+        }
+      }
+    return httpSecurity.build()
+  }
+
+  @Bean
+  fun passwordEncoder(): BCryptPasswordEncoder {
+    return BCryptPasswordEncoder()
+  }
+
+  @Bean
+  fun authenticationProvider(): AuthenticationProvider {
+    return DaoAuthenticationProvider()
+      .apply {
+        this.setUserDetailsService(userDetailsService)
+        this.setPasswordEncoder(passwordEncoder())
+      }
+  }
+
+  @Bean
+  fun authenticationManager(config: AuthenticationConfiguration): AuthenticationManager {
+    return config.authenticationManager
+  }
+}

--- a/src/main/kotlin/chung/me/livechatapi/config/UserDetailsService.kt
+++ b/src/main/kotlin/chung/me/livechatapi/config/UserDetailsService.kt
@@ -1,0 +1,20 @@
+package chung.me.livechatapi.config
+
+import chung.me.livechatapi.repos.UserRepos
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+
+@Configuration
+class UserDetailsConfig(
+  private val userRepos: UserRepos,
+) {
+
+  @Bean
+  fun userDetailsService(): UserDetailsService {
+    return UserDetailsService { userId ->
+      userRepos.findByUserId(userId) ?: throw UsernameNotFoundException("User ($userId) not found")
+    }
+  }
+}

--- a/src/main/kotlin/chung/me/livechatapi/controller/UserController.kt
+++ b/src/main/kotlin/chung/me/livechatapi/controller/UserController.kt
@@ -1,0 +1,49 @@
+package chung.me.livechatapi.controller
+
+import chung.me.livechatapi.service.AuthService
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/users")
+class UserController(
+  private val authService: AuthService,
+) {
+
+  @PostMapping("signup")
+  @ResponseStatus(HttpStatus.CREATED)
+  fun signup(
+    @RequestBody body: AuthBody,
+    response: HttpServletResponse,
+  ) {
+    val (userId, password) = body
+    val (accessToken, refreshToken) = authService.register(userId, password)
+    response.setHeader("ACCESS_TOKEN", accessToken)
+    response.setHeader("REFRESH_TOKEN", refreshToken)
+  }
+
+  @PostMapping("signin")
+  fun signin(
+    @RequestBody body: AuthBody,
+  ): ResponseEntity<AuthenticationResponse> {
+    val (userId, password) = body
+    val authenticationResponse = authService.signin(userId, password)
+    return ResponseEntity.ok().body(authenticationResponse)
+  }
+}
+
+data class AuthBody(
+  val userId: String,
+  val password: String,
+)
+
+data class AuthenticationResponse(
+  val accessToken: String,
+  val refreshToken: String,
+)

--- a/src/main/kotlin/chung/me/livechatapi/entity/RefreshToken.kt
+++ b/src/main/kotlin/chung/me/livechatapi/entity/RefreshToken.kt
@@ -1,0 +1,22 @@
+package chung.me.livechatapi.entity
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import org.springframework.data.mongodb.core.mapping.Encrypted
+import org.springframework.data.mongodb.core.mapping.MongoId
+import java.time.LocalDateTime
+
+@Document
+class RefreshToken(
+  val userId: String,
+  @Encrypted var token: String,
+) {
+  @MongoId
+  lateinit var id: ObjectId
+
+  @Indexed(expireAfterSeconds = 604800)
+  @CreatedDate
+  lateinit var createdAt: LocalDateTime
+}

--- a/src/main/kotlin/chung/me/livechatapi/entity/User.kt
+++ b/src/main/kotlin/chung/me/livechatapi/entity/User.kt
@@ -4,16 +4,51 @@ import org.bson.types.ObjectId
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.mongodb.core.mapping.Document
 import org.springframework.data.mongodb.core.mapping.MongoId
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
 import java.time.LocalDateTime
 
 @Document
 class User(
   var userId: String,
-  var password: String,
-) {
+  private val password: String,
+) : UserDetails {
   @MongoId
   lateinit var id: ObjectId
 
   @CreatedDate
   lateinit var createdAt: LocalDateTime
+  var role: Role = Role.MEMBER
+  override fun getAuthorities(): List<GrantedAuthority> {
+    return listOf(SimpleGrantedAuthority(role.name))
+  }
+
+  override fun getPassword(): String {
+    return password
+  }
+
+  override fun getUsername(): String {
+    return userId
+  }
+
+  override fun isAccountNonExpired(): Boolean {
+    return true
+  }
+
+  override fun isAccountNonLocked(): Boolean {
+    return true
+  }
+
+  override fun isCredentialsNonExpired(): Boolean {
+    return true
+  }
+
+  override fun isEnabled(): Boolean {
+    return true
+  }
+}
+
+enum class Role(key: String, title: String) {
+  MEMBER("MEMBER", "회원"),
 }

--- a/src/main/kotlin/chung/me/livechatapi/repos/RefreshTokenRepos.kt
+++ b/src/main/kotlin/chung/me/livechatapi/repos/RefreshTokenRepos.kt
@@ -1,0 +1,9 @@
+package chung.me.livechatapi.repos
+
+import chung.me.livechatapi.entity.RefreshToken
+import org.bson.types.ObjectId
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface RefreshTokenRepos : MongoRepository<RefreshToken, ObjectId> {
+  fun findByUserId(userId: String): RefreshToken?
+}

--- a/src/main/kotlin/chung/me/livechatapi/repos/UserRepos.kt
+++ b/src/main/kotlin/chung/me/livechatapi/repos/UserRepos.kt
@@ -4,4 +4,6 @@ import chung.me.livechatapi.entity.User
 import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
 
-interface UserRepos : MongoRepository<User, ObjectId>
+interface UserRepos : MongoRepository<User, ObjectId> {
+  fun findByUserId(userId: String): User?
+}

--- a/src/main/kotlin/chung/me/livechatapi/service/AuthService.kt
+++ b/src/main/kotlin/chung/me/livechatapi/service/AuthService.kt
@@ -1,0 +1,65 @@
+package chung.me.livechatapi.service
+
+import chung.me.livechatapi.config.JwtService
+import chung.me.livechatapi.controller.AuthenticationResponse
+import chung.me.livechatapi.entity.RefreshToken
+import chung.me.livechatapi.entity.User
+import chung.me.livechatapi.repos.RefreshTokenRepos
+import chung.me.livechatapi.repos.UserRepos
+import org.springframework.http.HttpStatus
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+
+@Service
+class AuthService(
+  private val userRepos: UserRepos,
+  private val passwordEncoder: PasswordEncoder,
+  private val jwtService: JwtService,
+  private val refreshTokenRepos: RefreshTokenRepos,
+) {
+
+  fun register(userId: String, password: String): AuthenticationResponse {
+    val existUser = userRepos.findByUserId(userId)
+
+    if (existUser != null) {
+      throw ResponseStatusException(HttpStatus.CONFLICT, "userId is duplicated")
+    }
+
+    val encodedPassword = passwordEncoder.encode(password)
+    val newUser = userRepos.save(User(userId, encodedPassword))
+    val accessToken = jwtService.generateAccessToken(newUser)
+    val refreshToken = jwtService.generateRefreshToken(newUser)
+
+    refreshTokenRepos.save(RefreshToken(userId, refreshToken))
+
+    return AuthenticationResponse(accessToken, refreshToken)
+  }
+
+  fun signin(userId: String, password: String): AuthenticationResponse {
+    val user = userRepos.findByUserId(userId) ?: throw ResponseStatusException(
+      HttpStatus.BAD_REQUEST,
+      "user ID is not exists. : $userId"
+    )
+
+    val matches = passwordEncoder.matches(password, user.password)
+
+    if (!matches) {
+      throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "Wrong password.")
+    }
+
+    val newAccessToken = jwtService.generateAccessToken(user)
+    val newRefreshToken = jwtService.generateRefreshToken(user)
+
+    val refreshToken = refreshTokenRepos.findByUserId(userId)
+
+    if (refreshToken == null) {
+      refreshTokenRepos.save(RefreshToken(userId, newRefreshToken))
+    } else {
+      refreshToken.token = newRefreshToken
+      refreshTokenRepos.save(refreshToken)
+    }
+
+    return AuthenticationResponse(newAccessToken, newRefreshToken)
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,3 +6,6 @@ spring:
       password: root
       database: chat
       authentication-database: admin
+  server:
+    secretKey: "614E645267556B58703272357538782F413F4428472B4B6250655368566D5971"
+

--- a/src/test/kotlin/chung/me/livechatapi/SpringMvcMockTestSupport.kt
+++ b/src/test/kotlin/chung/me/livechatapi/SpringMvcMockTestSupport.kt
@@ -1,0 +1,120 @@
+package chung.me.livechatapi
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import java.net.URI
+
+@TestPropertySource(properties = ["de.flapdoodle.mongodb.embedded.version=3.6.5"])
+@AutoConfigureDataMongo
+@SpringBootTest(
+  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+)
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@AutoConfigureMockMvc
+abstract class SpringMvcMockTestSupport {
+
+  @Autowired
+  private lateinit var mockMvc: MockMvc
+
+  @Autowired
+  lateinit var objectMapper: ObjectMapper
+
+  fun parseJson(value: Any): String {
+    return objectMapper.writeValueAsString(value)
+  }
+
+  fun performGet(url: String, params: Map<String, String>? = null, headers: Map<String, Any>? = null): ResultActions {
+    return getBuilder(MockMvcRequestBuilders::get, url, params, null, headers).let {
+      mockMvc.perform(it)
+    }
+  }
+
+  private fun getBuilder(
+    method: (URI) -> MockHttpServletRequestBuilder,
+    url: String,
+    params: Map<String, String>? = null,
+    body: Any? = null,
+    headers: Map<String, Any>? = null,
+  ): MockHttpServletRequestBuilder {
+    val builder = method(URI.create(url))
+      .contentType(MediaType.APPLICATION_JSON)
+
+    addParams(params, builder)
+    addBody(body, builder)
+    addHeaders(headers, builder)
+
+    return builder
+  }
+
+  private fun addParams(
+    params: Map<String, String>?,
+    builder: MockHttpServletRequestBuilder,
+  ) {
+    params?.forEach { (key, value) ->
+      builder.param(key, value)
+    }
+  }
+
+  private fun addBody(
+    body: Any?,
+    builder: MockHttpServletRequestBuilder,
+  ) {
+    body?.let {
+      builder.content(parseJson(it))
+    }
+  }
+
+  private fun addHeaders(
+    headers: Map<String, Any>?,
+    builder: MockHttpServletRequestBuilder,
+  ) {
+    headers?.let {
+      it.forEach { (k, v) ->
+        builder.header(k, v)
+      }
+    }
+  }
+
+  fun performPost(url: String, body: Any? = null, headers: Map<String, Any>? = null): ResultActions {
+    return getBuilder(MockMvcRequestBuilders::post, url, null, body, headers).let {
+      mockMvc.perform(it)
+    }
+  }
+
+  fun performPut(url: String, body: Any? = null, headers: Map<String, Any>? = null): ResultActions {
+    return getBuilder(MockMvcRequestBuilders::put, url, null, body, headers).let {
+      mockMvc.perform(it)
+    }
+  }
+
+  fun performDelete(
+    url: String,
+    params: Map<String, String>? = null,
+    headers: Map<String, Any>? = null,
+  ): ResultActions {
+    return getBuilder(MockMvcRequestBuilders::delete, url, params, null, headers).let {
+      mockMvc.perform(it)
+    }
+  }
+
+  final inline fun <reified T> toResult(response: MockHttpServletResponse): T {
+    return toResult(response.contentAsString)
+  }
+
+  final inline fun <reified T> toResult(json: String): T {
+    val typeReference = object : TypeReference<T>() {}
+    return objectMapper.readValue(json, typeReference)
+  }
+}

--- a/src/test/kotlin/chung/me/livechatapi/controller/UserControllerTest.kt
+++ b/src/test/kotlin/chung/me/livechatapi/controller/UserControllerTest.kt
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class UserControllerTest(
   private val userRepos: UserRepos,
@@ -46,7 +48,9 @@ class UserControllerTest(
     val signupResponse = performPost("/users/signup", body).andReturn().response
     val firstRefreshToken = signupResponse.getHeader("REFRESH_TOKEN")
 
-    Thread.sleep(100)
+    val latch = CountDownLatch(1)
+    latch.await(500, TimeUnit.MILLISECONDS)
+
     val response = performPost("/users/signin", body).andReturn().response
     assertEquals(response.status, HttpStatus.OK.value())
     val (accessToken, refreshToken) = toResult<AuthenticationResponse>(response)

--- a/src/test/kotlin/chung/me/livechatapi/controller/UserControllerTest.kt
+++ b/src/test/kotlin/chung/me/livechatapi/controller/UserControllerTest.kt
@@ -1,0 +1,64 @@
+package chung.me.livechatapi.controller
+
+import chung.me.livechatapi.SpringMvcMockTestSupport
+import chung.me.livechatapi.repos.RefreshTokenRepos
+import chung.me.livechatapi.repos.UserRepos
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class UserControllerTest(
+  private val userRepos: UserRepos,
+  private val refreshTokenRepos: RefreshTokenRepos,
+) : SpringMvcMockTestSupport() {
+
+  @BeforeEach
+  fun setUp() {
+    userRepos.deleteAll()
+    refreshTokenRepos.deleteAll()
+  }
+
+  @Test
+  fun `회원 가입 테스트`() {
+    val response = performPost("/users/signup", AuthBody("user1", "password123")).andReturn().response
+    assertEquals(response.status, HttpStatus.CREATED.value())
+
+    assertNotNull(response.getHeader("ACCESS_TOKEN"))
+    val refreshToken = response.getHeader("REFRESH_TOKEN")
+    assertNotNull(refreshToken)
+    val savedToken = refreshTokenRepos.findByUserId("user1")?.token
+    assertEquals(savedToken, refreshToken)
+    assertNotNull(userRepos.findByUserId("user1"))
+  }
+
+  @Test
+  fun `회원가입 후 로그인 테스트`() {
+    val body = AuthBody("user1", "password123")
+    val signupResponse = performPost("/users/signup", body).andReturn().response
+    val firstRefreshToken = signupResponse.getHeader("REFRESH_TOKEN")
+
+    Thread.sleep(100)
+    val response = performPost("/users/signin", body).andReturn().response
+    assertEquals(response.status, HttpStatus.OK.value())
+    val (accessToken, refreshToken) = toResult<AuthenticationResponse>(response)
+    assertNotNull(accessToken)
+    assertNotNull(refreshToken)
+    assertNotEquals(firstRefreshToken, refreshToken)
+    assertEquals(refreshTokenRepos.findByUserId("user1")?.token, refreshToken)
+  }
+
+  @Test
+  fun `없는 아이디로 로그인 테스트`() {
+    val body = AuthBody("user1", "password123")
+    val response = performPost("/users/signin", body).andReturn().response
+    assertEquals(response.status, HttpStatus.BAD_REQUEST.value())
+  }
+
+  @Test
+  fun `틀린 비밀번호로 로그인 테스트`() {
+    performPost("/users/signup", AuthBody("user1", "password123"))
+    val response = performPost("/users/signin", AuthBody("user1", "password")).andReturn().response
+    assertEquals(response.status, HttpStatus.UNAUTHORIZED.value())
+  }
+}

--- a/src/test/kotlin/chung/me/livechatapi/controller/UserControllerTest.kt
+++ b/src/test/kotlin/chung/me/livechatapi/controller/UserControllerTest.kt
@@ -1,6 +1,7 @@
 package chung.me.livechatapi.controller
 
 import chung.me.livechatapi.SpringMvcMockTestSupport
+import chung.me.livechatapi.entity.User
 import chung.me.livechatapi.repos.RefreshTokenRepos
 import chung.me.livechatapi.repos.UserRepos
 import org.junit.jupiter.api.Assertions.*
@@ -30,6 +31,13 @@ class UserControllerTest(
     val savedToken = refreshTokenRepos.findByUserId("user1")?.token
     assertEquals(savedToken, refreshToken)
     assertNotNull(userRepos.findByUserId("user1"))
+  }
+
+  @Test
+  fun `회원 가입 아이디 중복 테스트`() {
+    userRepos.save(User("user1", "pass"))
+    val response = performPost("/users/signup", AuthBody("user1", "password123")).andReturn().response
+    assertEquals(response.status, HttpStatus.CONFLICT.value())
   }
 
   @Test

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -3,3 +3,5 @@ spring:
     mongodb:
       username: test
       password: test
+  server:
+    secretKey: "614E645267556B58703272357538782F413F4428472B4B6250655368566D5971"

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.config.dynamic.factor=1


### PR DESCRIPTION
# 회원가입
POST `/users/signup`

```json
{
  userId: "user1",
  password: "pass123"
}
```

ACCESS_TOKEN, REFRESH_TOKEN 헤더에 각 토큰을 담아 반환

----

# 로그인
POST `/users/signin`

```json
{
  userId: "user1",
  password: "pass123"
}
```

## 정상 수행시
200 상태 코드와 다음 값 반환
```json
{
  accessToken: "...",
  refreshToken: "..."
}
```
## 없는 아이디로 시도시
400 코드 반환
## 비밀번호 틀릴 시
401 코드 반환

-----
refresh token 으로 access token 재생성하는 api 는 아직