### PR TITLE
5 docker image

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -29,7 +29,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@4
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -37,7 +37,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@4
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64/v8
       # Login Docker registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -54,3 +54,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+        platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }},hyper-web-space/live-chat-api:latest
+          tags: ${{ steps.meta.outputs.tags }},ghcr.io/hyper-web-space/live-chat-api:latest
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -19,6 +19,7 @@ jobs:
       # This is used to complete the identity challenge
       # with sigstore/fulcio when running outside of PRs.
       id-token: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - name: Setup Docker buildx

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
       # Login Docker registry

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -35,7 +35,6 @@ jobs:
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - cmd: buildx create --use
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@4

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -54,4 +54,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-        platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -1,5 +1,11 @@
 name: Docker Image Build
 
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
 on:
   push:
     branches: [ 5-docker-image ]

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
       # Login Docker registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -13,6 +13,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - name: Setup Docker buildx

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -14,10 +14,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
       # Login Docker registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -27,15 +29,16 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
+      - cmd: buildx create --use
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@4
         with:
           context: .
           push: true

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }},hyper-web-space/live-chat-api:latest
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -19,7 +19,6 @@ jobs:
       # This is used to complete the identity challenge
       # with sigstore/fulcio when running outside of PRs.
       id-token: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - name: Setup Docker buildx

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -1,0 +1,39 @@
+name: Docker Image Build
+
+on:
+  push:
+    branches: [ 5-docker-image ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Login Docker registry
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -8,7 +8,7 @@ env:
 
 on:
   push:
-    branches: [ 5-docker-image ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,8 +7,6 @@ on: # Event
 jobs:
   test: # Job id
     runs-on: ubuntu-latest # Runner
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@v3 # Step
       - name: Set up JDK 17
@@ -29,6 +27,8 @@ jobs:
           fail_ci_if_error: true
   codeball_job:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     name: Codeball
     steps:
       - name: Codeball

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,8 @@ on: # Event
 jobs:
   test: # Job id
     runs-on: ubuntu-latest # Runner
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3 # Step
       - name: Set up JDK 17

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+mongo-data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:17-jdk-slim AS builder
+COPY ./ /tmp
+WORKDIR /tmp
+RUN ./gradlew clean bootJar
+
+FROM openjdk:17-jdk-slim
+COPY --from=builder /tmp/build/libs/live-chat-api.jar /app/app.jar
+WORKDIR /app
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "./app.jar"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+docker-build:
+	docker build -t live-chat-api:latest .
+up:
+	docker compose up -d
+down:
+	docker compose down

--- a/README.md
+++ b/README.md
@@ -3,7 +3,63 @@
 Redis와 WebSocket을 이용한 라이브 채팅 API
 
 # 아키텍처
+
 ![아키텍처 다이어그램](./docs/resources/images/live-chat-api-architecture.png)
+
 * 웹소켓을 이용하여 클라이언트와 실시간 통신
 * 레디스 Pub/Sub 을 이용하여 여러 서버에 접속한 클라이언트에게 메시지 전송
 * 레디스에 저장된 메시지를 워커에서 몽고디비로 저장
+
+# 빌드
+
+## gradle
+
+```shell
+$ gradlew bootJar
+```
+
+## 도커 빌드 및 이미지 생성
+
+```shell
+$ make docker-build
+```
+
+# 실행
+
+```shell
+$ java -jar build/libs/live-chat-api.jar
+```
+
+## docker-compose 로 실행
+
+```shell
+$ docker-compose up -d
+```
+
+### docker-compose.yaml 예시
+
+```yaml
+version: "3.9"
+
+services:
+  api:
+    image: live-chat-api
+    ports:
+      - "8080:8080"
+    environment:
+      MONGODB_URL: mongodb://mongo:27017
+      username: root
+      password: root
+    depends_on:
+      - mongo
+  mongo:
+    image: mongo
+    restart: always
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: root
+    volumes:
+      - ./mongo-data:/data/db
+```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ version: "3.9"
 
 services:
   api:
-    image: live-chat-api
+    image: ghcr.io/hyper-web-space/live-chat-api
     ports:
       - "8080:8080"
     environment:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
   id("org.springframework.boot") version "3.0.5"
@@ -54,4 +55,8 @@ tasks {
       html.required.set(true)
     }
   }
+}
+
+tasks.withType<BootJar> {
+  archiveFileName.set("${project.name}.jar")
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   api:
-    image: live-chat-api
+    image: ghcr.io/hyper-web-space/live-chat-api
     ports:
       - "8080:8080"
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: "3.9"
+
+services:
+  api:
+    image: live-chat-api
+    ports:
+      - "8080:8080"
+    environment:
+      MONGODB_URL: mongodb://mongo:27017
+      username: root
+      password: root
+    depends_on:
+      - mongo
+  mongo:
+    image: mongo
+    restart: always
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: root
+    volumes:
+      - ./mongo-data:/data/db

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,11 +1,10 @@
 spring:
   data:
     mongodb:
-      uri: mongodb://localhost:27017
-      username: root
-      password: root
+      uri: ${MONGODB_URL:mongodb://localhost:27017}
+      username: ${MONGODB_USERNAME:root}
+      password: ${MONGODB_PASSWORD:root}
       database: chat
       authentication-database: admin
   server:
-    secretKey: "614E645267556B58703272357538782F413F4428472B4B6250655368566D5971"
-
+    secretKey: ${SECRET_KEY:"614E645267556B58703272357538782F413F4428472B4B6250655368566D5971"}


### PR DESCRIPTION
깃헙 액션으로 main 브랜치에 푸시되면 도커 이미지 빌드 후 배포하게 설정

```yaml
version: "3.9"

services:
  api:
    image: ghcr.io/hyper-web-space/live-chat-api
    ports:
      - "8080:8080"
    environment:
      MONGODB_URL: mongodb://mongo:27017
      username: root
      password: root
    depends_on:
      - mongo
  mongo:
    image: mongo
    restart: always
    ports:
      - "27017:27017"
    environment:
      MONGO_INITDB_ROOT_USERNAME: root
      MONGO_INITDB_ROOT_PASSWORD: root
    volumes:
      - ./mongo-data:/data/db
```

위에 내용으로 도커 컴포즈 파일 생성 후 실행할 수 있음