### PR TITLE
redis pub/sub 으로 멀티 서버 메시지 전송, 메시지 저장

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 mongo-data/
+/output/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ version: "3.9"
 services:
   api:
     image: ghcr.io/hyper-web-space/live-chat-api:latest
+    restart: always
     ports:
       - "8080:8080"
     environment:
@@ -52,6 +53,7 @@ services:
       MONGODB_PASSWORD: root
     depends_on:
       - mongo
+      - redis
   mongo:
     image: mongo
     restart: always
@@ -62,4 +64,9 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: root
     volumes:
       - ./mongo-data:/data/db
+  redis:
+    restart: always
+    image: redis:latest
+    ports:
+      - "6379:6379"
 ```

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -1,0 +1,54 @@
+asyncapi: '2.6.0'
+info:
+  title: Streetlights Kafka API
+  version: '1.0.0'
+  description: |
+    메시지 전송을 위한 WebSocket STOMP 명세
+
+    연결시 Authorization 헤더에 jwt 토큰을 추가해야 한다.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+servers:
+  api:
+    url: ws://localhost:8080/ws
+    protocol: ws
+defaultContentType: application/json
+channels:
+  /queue/message/$chatRoomId:
+    publish:
+      summary: 메시지 발신
+      operationId: sendMessage
+      message:
+        $ref: '#/components/messages/chatData'
+  /chat/$chatRoomId:
+    subscribe:
+      summary: 메시지 수신
+      operationId: receiveMessage
+      message:
+        $ref: '#/components/messages/chatData'
+components:
+  messages:
+    chatData:
+      title: 채팅 데이터
+      summary: 채팅 데이터에 대한 정보
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/chatDataPayload"
+  schemas:
+    chatDataPayload:
+      type: object
+      properties:
+        sender:
+          type: string
+          description: 전송자 ID
+          example: "user123"
+        contents:
+          type: string
+          description: 채팅 내용
+          example: "hi~"
+        messageTimestamp:
+          type: string
+          description: 채팅 입력 시간
+          format: yyyy-MM-dd HH:mm:ss.SSS
+          example: "2023-05-10 23:11:00.000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,7 @@ version: "3.9"
 services:
   api:
     image: ghcr.io/hyper-web-space/live-chat-api:latest
+    restart: always
     ports:
       - "8080:8080"
     environment:
@@ -11,6 +12,7 @@ services:
       MONGODB_PASSWORD: root
     depends_on:
       - mongo
+      - redis
   mongo:
     image: mongo
     restart: always
@@ -21,3 +23,8 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: root
     volumes:
       - ./mongo-data:/data/db
+  redis:
+    restart: always
+    image: redis:latest
+    ports:
+      - "6379:6379"

--- a/src/main/kotlin/chung/me/livechatapi/config/AuthChannelInterceptorAdaptor.kt
+++ b/src/main/kotlin/chung/me/livechatapi/config/AuthChannelInterceptorAdaptor.kt
@@ -1,6 +1,7 @@
 package chung.me.livechatapi.config
 
 import chung.me.livechatapi.service.AuthService
+import org.springframework.http.HttpHeaders
 import org.springframework.messaging.Message
 import org.springframework.messaging.MessageChannel
 import org.springframework.messaging.simp.stomp.StompCommand
@@ -18,7 +19,8 @@ class AuthChannelInterceptorAdaptor(
     val accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor::class.java)
 
     if (accessor != null && StompCommand.CONNECT == accessor.command) {
-      val authorizationHeader = accessor.getNativeHeader("Authorization") ?: return null
+      val authorizationHeader = accessor.getNativeHeader(HttpHeaders.AUTHORIZATION)
+        ?: throw RuntimeException("${HttpHeaders.AUTHORIZATION} header is not exist")
 
       authorizationHeader[0]?.let { token ->
         accessor.user = authService.getUsernamePasswordAuthenticationToken(token)

--- a/src/main/kotlin/chung/me/livechatapi/config/RedisConfig.kt
+++ b/src/main/kotlin/chung/me/livechatapi/config/RedisConfig.kt
@@ -1,86 +1,39 @@
 package chung.me.livechatapi.config
 
+import chung.me.livechatapi.redis.RedisSubscriber
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.listener.ChannelTopic
 import org.springframework.data.redis.listener.RedisMessageListenerContainer
-import org.springframework.data.redis.listener.adapter.MessageListenerAdapter
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.StringRedisSerializer
-import java.io.Serializable
 
 @Configuration
 class RedisConfig {
   @Bean
   fun redisMessageListenerContainer(
     connectionFactory: RedisConnectionFactory,
-    listenerAdapter: MessageListenerAdapter,
-    channelTopic: ChannelTopic,
+    redisSubscriber: RedisSubscriber
   ): RedisMessageListenerContainer {
     return RedisMessageListenerContainer()
       .also {
         it.setConnectionFactory(connectionFactory)
-        it.addMessageListener(listenerAdapter, channelTopic)
+        it.addMessageListener(redisSubscriber, ChannelTopic("chat"))
       }
   }
 
   @Bean
-  fun listenerAdapter(): MessageListenerAdapter {
-    return MessageListenerAdapter(DefaultMessageDelegate(), "handleMessage")
-  }
-
-  @Bean
-  fun channelTopic(): ChannelTopic {
-    return ChannelTopic("chat")
-  }
-
-  @Bean
-  fun redisTemplate(
+  fun <T : Any> redisTemplate(
     connectionFactory: RedisConnectionFactory,
-  ): RedisTemplate<String, Any> {
-    return RedisTemplate<String, Any>().also {
+    objectMapper: ObjectMapper,
+  ): RedisTemplate<String, T> {
+    return RedisTemplate<String, T>().also {
       it.setConnectionFactory(connectionFactory)
       it.keySerializer = StringRedisSerializer()
-      it.valueSerializer = Jackson2JsonRedisSerializer(String::class.java)
+      it.valueSerializer = Jackson2JsonRedisSerializer(objectMapper, String::class.java)
     }
   }
 }
-
-interface MessageDelegate {
-  fun handleMessage(message: String?)
-  fun handleMessage(message: Map<*, *>?)
-  fun handleMessage(message: ByteArray?)
-  fun handleMessage(message: Serializable?)
-
-  // pass the channel/pattern as well
-  fun handleMessage(message: Serializable?, channel: String?)
-}
-
-class DefaultMessageDelegate : MessageDelegate { // implementation elided for clarity...
-  override fun handleMessage(message: String?) {
-    println(message)
-  }
-
-  override fun handleMessage(message: Map<*, *>?) {
-    println(message)
-  }
-
-  override fun handleMessage(message: ByteArray?) {
-    println(message)
-  }
-
-  override fun handleMessage(message: Serializable?) {
-    println(message)
-  }
-
-  override fun handleMessage(message: Serializable?, channel: String?) {
-    println(message)
-  }
-}
-
-data class RedisMessage(
-  val roomId: String,
-  val message: String,
-)

--- a/src/main/kotlin/chung/me/livechatapi/controller/ChattingController.kt
+++ b/src/main/kotlin/chung/me/livechatapi/controller/ChattingController.kt
@@ -30,6 +30,8 @@ class ChattingController(
       return
     }
 
+    chattingService.saveAndPublish(roomId, chatData)
+
     logger().debug("send message to /chat/$roomId")
     simpleMessageSendingOperations.convertAndSend("/chat/$roomId", chatData)
   }

--- a/src/main/kotlin/chung/me/livechatapi/redis/RedisChatMessage.kt
+++ b/src/main/kotlin/chung/me/livechatapi/redis/RedisChatMessage.kt
@@ -1,0 +1,22 @@
+package chung.me.livechatapi.redis
+
+import chung.me.livechatapi.controller.ChatData
+import java.io.Serializable
+import java.time.LocalDateTime
+
+data class RedisChatMessage(
+  val roomId: String,
+  val sender: String,
+  val content: String,
+  val messageTimestamp: LocalDateTime,
+) : Serializable {
+  companion object {
+    fun of(roomId: String, chatData: ChatData) =
+      RedisChatMessage(
+        roomId = roomId,
+        sender = chatData.sender,
+        content = chatData.contents,
+        messageTimestamp = chatData.messageTimestamp
+      )
+  }
+}

--- a/src/main/kotlin/chung/me/livechatapi/redis/RedisPublisher.kt
+++ b/src/main/kotlin/chung/me/livechatapi/redis/RedisPublisher.kt
@@ -1,0 +1,17 @@
+package chung.me.livechatapi.redis
+
+import chung.me.livechatapi.controller.ChatData
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class RedisPublisher(
+  private val redisTemplate: RedisTemplate<String, RedisChatMessage>,
+) {
+
+  fun publish(roomId: String, chatData: ChatData) {
+    RedisChatMessage.of(roomId, chatData).let {
+      redisTemplate.convertAndSend("chat", it)
+    }
+  }
+}

--- a/src/main/kotlin/chung/me/livechatapi/redis/RedisSubscriber.kt
+++ b/src/main/kotlin/chung/me/livechatapi/redis/RedisSubscriber.kt
@@ -1,0 +1,31 @@
+package chung.me.livechatapi.redis
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter
+import org.springframework.messaging.MessagingException
+import org.springframework.messaging.simp.SimpMessageSendingOperations
+import org.springframework.stereotype.Component
+
+@Component
+class RedisSubscriber(
+  private val simpleMessageSendingOperations: SimpMessageSendingOperations,
+  private val objectMapper: ObjectMapper,
+) : MessageListenerAdapter() {
+
+  companion object {
+    private val logger = LoggerFactory.getLogger(RedisSubscriber::class.java)
+  }
+
+  // RedisChatMessage 를 redis sub으로 받아서 웹소켓 /chat/${RedisChatMessage.roomId} 로 메시지를 보낸다.
+  override fun onMessage(message: Message, pattern: ByteArray?) {
+    val redisChatMessage = objectMapper.readValue<RedisChatMessage>(message.body)
+    try {
+      simpleMessageSendingOperations.convertAndSend("/chat/${redisChatMessage.roomId}", redisChatMessage)
+    } catch (e: MessagingException) {
+      logger.error("Failed send message to /chat/${redisChatMessage.roomId}, MessagingException occurred. message: ${e.message}")
+    }
+  }
+}

--- a/src/main/kotlin/chung/me/livechatapi/service/ChattingService.kt
+++ b/src/main/kotlin/chung/me/livechatapi/service/ChattingService.kt
@@ -1,6 +1,37 @@
 package chung.me.livechatapi.service
 
+import chung.me.livechatapi.controller.ChatData
+import chung.me.livechatapi.entity.Message
+import chung.me.livechatapi.redis.RedisPublisher
+import chung.me.livechatapi.repos.MessageRepos
+import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
-class ChattingService
+class ChattingService(
+  private val messageRepos: MessageRepos,
+  private val redisPublisher: RedisPublisher,
+) {
+
+  @Transactional
+  fun saveAndPublish(roomId: String, chatData: ChatData) {
+    saveMessage(roomId, chatData)
+    publishMessageToRedis(roomId, chatData)
+  }
+
+  // fixme : 나중에 워커로 이동될 예정
+  private fun saveMessage(roomId: String, chatData: ChatData) {
+    messageRepos.save(
+      Message(
+        roomId = ObjectId(roomId),
+        sender = chatData.sender,
+        content = chatData.contents
+      )
+    )
+  }
+
+  private fun publishMessageToRedis(roomId: String, chatData: ChatData) {
+    redisPublisher.publish(roomId, chatData)
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,3 +16,10 @@ springdoc:
   enable-data-rest: false
   enable-groovy: false
   enable-hateoas: false
+---
+spring:
+  config:
+    activate:
+      on-profile: 8081
+server:
+  port: 8081

--- a/src/test/kotlin/chung/me/livechatapi/controller/ChattingControllerTest.kt
+++ b/src/test/kotlin/chung/me/livechatapi/controller/ChattingControllerTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpHeaders
 import org.springframework.messaging.converter.MappingJackson2MessageConverter
 import org.springframework.messaging.simp.stomp.StompCommand
 import org.springframework.messaging.simp.stomp.StompHeaders
@@ -146,7 +147,7 @@ class ChattingControllerTest(
     val principal = authentication.principal as User
     val token = jwtService.generateAccessToken(principal)
 
-    stompHeaders.add("Authorization", token)
+    stompHeaders.add(HttpHeaders.AUTHORIZATION, token)
     return stompHeaders
   }
 }


### PR DESCRIPTION
1. 도커 컴포즈 파일 변경 (레디스 추가)
```yaml
version: "3.9"

services:
  api:
    image: ghcr.io/hyper-web-space/live-chat-api:latest
    restart: always
    ports:
      - "8080:8080"
    environment:
      MONGODB_HOST: mongo
      MONGODB_USERNAME: root
      MONGODB_PASSWORD: root
    depends_on:
      - mongo
      - redis
  mongo:
    image: mongo
    restart: always
    ports:
      - "27017:27017"
    environment:
      MONGO_INITDB_ROOT_USERNAME: root
      MONGO_INITDB_ROOT_PASSWORD: root
    volumes:
      - ./mongo-data:/data/db
  redis:
    restart: always
    image: redis:latest
    ports:
      - "6379:6379"

```

2. [웹소켓 STOMP 문서 추가](https://github.com/hyper-web-space/live-chat-api/wiki/WebSocket-STOMP-%EB%AA%85%EC%84%B8)
swagger 처럼 서버에서 반환하려고 했으나 실패해서 그냥 위키에 올려버림.. 웹 버전이 더 깔끔한데..